### PR TITLE
Wip bugfixes

### DIFF
--- a/src/main/scala/PlayScrapePlugin.scala
+++ b/src/main/scala/PlayScrapePlugin.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.net.URL
 import java.util.{ List => JList }
 
-import sbt.{ AutoPlugin, Def, taskKey, settingKey, Project, Compile, State, Path }, Path._
+import sbt.{ AutoPlugin, Def, IO, taskKey, settingKey, Project, Compile, State, Path }, Path._
 import sbt.Keys._
 
 import play.Play
@@ -109,6 +109,8 @@ object PlayScrapePlugin extends AutoPlugin {
     },
     (scrapePlay in Compile) := {
       val customSettings: Map[String, String] = if (scrapeContext.value == "") Map() else Map("application.context" -> scrapeContext.value)
+      IO.delete(scrapeTarget.value)
+      IO.createDirectory(scrapeTarget.value)
       scrapeAssets(playAllAssets.value, scrapeTarget.value, scrapeLoader.value, customSettings)
       scrapeSpecifiedRoutes(baseDirectory.value, scrapeTarget.value, scrapeLoader.value, scrapeRoutes.value, scrapeDelay.value, customSettings, scrapeAbsoluteURL.value)
     })

--- a/src/main/scala/ScrapeTasks.scala
+++ b/src/main/scala/ScrapeTasks.scala
@@ -54,12 +54,13 @@ object ScrapeTasks {
   def scrapeAssets(playAssets: Seq[(String, File)], targetDirectory: File, loader: ClassLoader, customSettings: Map[String, String]) = {
     val (ssPathForAsset, ssInstance) = startServerMethod(loader, "pathForAsset", classOf[String])
     val lookupAssetPath = ((s: String) => ssPathForAsset.invoke(ssInstance, s).asInstanceOf[String])
-    copyFiles(
+    val filesToCopy =
       playAssets flatMap {
         case (displayPath, assetsDir) =>
           (assetsDir ***).get.flatMap(f =>
               relativeTo(assetsDir)(f).map(assetPath =>
                   (f, targetDirectory / customSettings.getOrElse("application.context", "") / lookupAssetPath(assetPath))))
-      })
+      }
+    copyFiles(filesToCopy, overwrite=true)
   }
 }

--- a/src/sbt-test/play-scraper/simple/CheckIdentical.sbt
+++ b/src/sbt-test/play-scraper/simple/CheckIdentical.sbt
@@ -1,0 +1,17 @@
+import Def.{ inputKey, spaceDelimited }
+
+val checkIdentical = inputKey[Unit]("check that two files are identical")
+
+def shasum(file: File): String =
+  Hash.toHex(Hash(file))
+
+checkIdentical := {
+  val args: Seq[String] = spaceDelimited("<file>").parsed
+  val fileA = file(".") / args(0)
+  val fileB = file(".") / args(1)
+
+  if (shasum(fileA) != shasum(fileB)) {
+    sys.error("expected " + fileA.toString + " (" + shasum(fileA) + ")  to match " +
+      fileB.toString + " (" + shasum(fileB) + ") but they did not match")
+  }
+}

--- a/src/sbt-test/play-scraper/simple/build.sbt
+++ b/src/sbt-test/play-scraper/simple/build.sbt
@@ -5,5 +5,3 @@ version := "1.0-SNAPSHOT"
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
 scalaVersion := "2.11.6"
-
-scrapeRoutes += "/favicon.png"

--- a/src/sbt-test/play-scraper/simple/build.sbt
+++ b/src/sbt-test/play-scraper/simple/build.sbt
@@ -5,3 +5,5 @@ version := "1.0-SNAPSHOT"
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
 scalaVersion := "2.11.6"
+
+scrapeRoutes += "/favicon.png"

--- a/src/sbt-test/play-scraper/simple/conf/routes
+++ b/src/sbt-test/play-scraper/simple/conf/routes
@@ -5,5 +5,8 @@
 # Home page
 GET     /                           controllers.Application.index
 
+GET     /favicon.png                controllers.Assets.at(path="/public", file="images/favicon.png")
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
+

--- a/src/sbt-test/play-scraper/simple/test
+++ b/src/sbt-test/play-scraper/simple/test
@@ -1,8 +1,16 @@
 > scrapePlay
 $ exists target/play-scrape
 $ exists target/play-scrape/assets
-$ exists target/play-scrape/assets/images/favicon.png
+$ exists target/play-scrape/assets/javascripts/hello.js
 $ sleep 10
 $ exists target/play-scrape/index.html
 $ exists target/play-scrape/favicon.png
-> checkIdentical target/play-scrape/favicon.png target/play-scrape/assets/images/favicon.png
+> checkIdentical public/images/favicon.png target/play-scrape/favicon.png
+# check that files that are removed from the project get removed from the scrape
+$ copy-file public/javascripts/hello.js public/javascripts/hello.js.bak
+$ delete public/javascripts/hello.js
+> scrapePlay
+-$ exists target/play-scrape/assets/javascripts/hello.js
+# reset
+$ copy-file public/javascripts/hello.js.bak public/javascripts/hello.js
+$ delete public/javascripts/hello.js.bak

--- a/src/sbt-test/play-scraper/simple/test
+++ b/src/sbt-test/play-scraper/simple/test
@@ -4,3 +4,5 @@ $ exists target/play-scrape/assets
 $ exists target/play-scrape/assets/images/favicon.png
 $ sleep 10
 $ exists target/play-scrape/index.html
+$ exists target/play-scrape/favicon.png
+> checkIdentical target/play-scrape/favicon.png target/play-scrape/assets/images/favicon.png


### PR DESCRIPTION
@qiemem or @TheBizzle , if you would care to review, please let me know any feedback you have, otherwise I'll plan to merge this in around 3 this afternoon and update Galapagos accordingly.

Fixes a problem we ran into yesterday where we were uploading corrupted png/ico files because the scraper had saved them to UTF-8 text files. Additionally, clears out old scrapes to avoid confusion with current scrapes.

In the process of writing this, I discovered that assets will be scraped without including their path in `scrapeRoutes`. For instance [this route](https://github.com/NetLogo/Play-Scraper/compare/wip-bugfixes?expand=1#diff-72faefd47900d0cce0ff4fbccd97d567R8) will cause `/favicon.png` to be automagically scraped without needing to do `scrapeRoutes += "/favicon.png"` in the build.sbt file.
