### PR TITLE
Update SBT to 1.x, Play to 2.6.12, AWS to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/netlogo/play-scraper"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.nlogo" % "play-scraper" % "0.7.4")
+addSbtPlugin("org.nlogo" % "play-scraper" % "0.8.0")
 ```
 
 In your `build.sbt`, add:
@@ -28,10 +28,12 @@ Note that version 0.7.0 is compatible only with Play 2.5. Versions of play earli
 To enable uploading, set the following keys:
 
 ```scala
-scrapePublishBucketID := "your-bucket"
+scrapePublishBucketID := Some("your-bucket")
 
-// this is optional, but if set the distribution will be invalidated on upload
-scrapePublishDistributionID := "your-cloudfront-distribution-id"
+scrapePublishRegion := Some("us-east-1")
+
+// this is optional. When set, the distribution will be invalidated on upload
+scrapePublishDistributionID := Some("your-cloudfront-distribution-id")
 ```
 
 As well as settings `scrapePublishCredentials` via one of the following methods:

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-lazy val playVersion = "2.6.1"
+lazy val playVersion = "2.6.12"
 
 lazy val sharedSettings = Seq(
   organization := "org.nlogo",
-  version      := "0.7.6",
+  version      := "0.8.0",
   isSnapshot   := true,
   resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
   licenses  += ("Public Domain", url("http://creativecommons.org/licenses/publicdomain/")),
@@ -26,12 +26,12 @@ lazy val playScrape = project.in(file("sbt-scrape-plugin")).
   settings(
     sbtPlugin           := true,
     name                := "play-scraper",
-    scalaVersion        := "2.10.6",
+    scalaVersion        := "2.12.4",
     scalacOptions       ++= Seq("-feature", "-deprecation"),
-    addSbtPlugin(("com.typesafe.play" % "sbt-plugin" % playVersion).extra("scalaVersion" -> "2.10")),
+    addSbtPlugin(("com.typesafe.play" % "sbt-plugin" % playVersion).extra("scalaVersion" -> "2.12")),
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-cloudfront" % "1.11.33",
-      "com.amazonaws" % "aws-java-sdk-s3"         % "1.11.33",
+      "com.amazonaws" % "aws-java-sdk-cloudfront" % "1.11.291",
+      "com.amazonaws" % "aws-java-sdk-s3"         % "1.11.291",
       "commons-codec" % "commons-codec"           % "1.10"
     ))
 
@@ -39,7 +39,7 @@ lazy val playScrapeServer = project.in(file("play-scrape-server")).
   settings(sharedSettings).
   settings(
     name                := "play-scrape-server",
-    scalaVersion        := "2.12.2",
+    scalaVersion        := "2.12.4",
     scalacOptions       ++= Seq("-deprecation"),
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % playVersion,
@@ -47,7 +47,6 @@ lazy val playScrapeServer = project.in(file("play-scrape-server")).
     ))
 
 lazy val scriptedSettings =
-  ScriptedPlugin.scriptedSettings ++
   Seq(
     scriptedLaunchOpts := { scriptedLaunchOpts.value ++
       Seq("-Xmx1024M", "-Dplugin.version=" + version.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,2 +1,2 @@
 libraryDependencies +=
-  "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/absolute/build.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/absolute/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 scrapeAbsoluteURL := Some("netlogoweb.org")

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/absolute/project/build.properties
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/absolute/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Mar 24 11:53:30 CDT 2015
 template.uuid=88679796-ef1c-40cd-82c2-d3114cfa2881
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/absolute/project/plugins.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/absolute/project/plugins.sbt
@@ -1,12 +1,12 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else addSbtPlugin("org.nlogo" % "play-scraper" % pluginVersion)
+    else addSbtPlugin("org.nlogo" %% "play-scraper" % pluginVersion)
 }

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/context/build.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/context/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 scrapeContext := "/sub/"

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/context/project/build.properties
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/context/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Mar 24 11:53:30 CDT 2015
 template.uuid=88679796-ef1c-40cd-82c2-d3114cfa2881
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/context/project/plugins.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/context/project/plugins.sbt
@@ -1,12 +1,12 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else addSbtPlugin("org.nlogo" % "play-scraper" % pluginVersion)
+    else addSbtPlugin("org.nlogo" %% "play-scraper" % pluginVersion)
 }

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/delay/build.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/delay/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 libraryDependencies ++= Seq(
   ehcache

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/delay/project/build.properties
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/delay/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Mar 24 11:53:30 CDT 2015
 template.uuid=88679796-ef1c-40cd-82c2-d3114cfa2881
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/delay/project/plugins.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/delay/project/plugins.sbt
@@ -1,12 +1,12 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else addSbtPlugin("org.nlogo" % "play-scraper" % pluginVersion)
+    else addSbtPlugin("org.nlogo" %% "play-scraper" % pluginVersion)
 }

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/simple/build.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/simple/build.sbt
@@ -4,4 +4,4 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/simple/project/build.properties
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/simple/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Mar 24 11:53:30 CDT 2015
 template.uuid=88679796-ef1c-40cd-82c2-d3114cfa2881
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/simple/project/plugins.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/simple/project/plugins.sbt
@@ -1,12 +1,12 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else addSbtPlugin("org.nlogo" % "play-scraper" % pluginVersion)
+    else addSbtPlugin("org.nlogo" %% "play-scraper" % pluginVersion)
 }

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/upload/build.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/upload/build.sbt
@@ -6,7 +6,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 scrapeRoutes += "/other"
 

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/upload/project/build.properties
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/upload/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Mar 24 11:53:30 CDT 2015
 template.uuid=88679796-ef1c-40cd-82c2-d3114cfa2881
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/upload/project/plugins.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/upload/project/plugins.sbt
@@ -1,12 +1,12 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else addSbtPlugin("org.nlogo" % "play-scraper" % pluginVersion)
+    else addSbtPlugin("org.nlogo" %% "play-scraper" % pluginVersion)
 }

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/build.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 pipelineStages ++= Seq(digest)

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/project/build.properties
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Mar 24 11:53:30 CDT 2015
 template.uuid=88679796-ef1c-40cd-82c2-d3114cfa2881
-sbt.version=0.13.15
+sbt.version=1.1.1

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/project/plugins.sbt
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/project/plugins.sbt
@@ -1,14 +1,14 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else addSbtPlugin("org.nlogo" % "play-scraper" % pluginVersion)
+    else addSbtPlugin("org.nlogo" %% "play-scraper" % pluginVersion)
 }

--- a/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/test
+++ b/sbt-scrape-plugin/src/sbt-test/play-scraper/versioned/test
@@ -1,16 +1,18 @@
 > scrapePlay
+$ sleep 10
 $ exists target/play-scrape
 $ exists target/play-scrape/assets
-> existsVersioned target/play-scrape/assets/javascripts/hello.js
-$ sleep 10
 $ exists target/play-scrape/index.html
+> existsVersioned target/play-scrape/assets/javascripts/hello.js
 > existsVersioned target/play-scrape/assets/images/favicon.png
 > checkIdenticalVersioned public/images/favicon.png target/play-scrape/assets/images/favicon.png
 # check that files that are removed from the project get removed from the scrape
-$ copy-file public/javascripts/hello.js public/javascripts/hello.js.bak
+$ copy-file public/javascripts/hello.js public/javascripts/hello-bak.js
 $ delete public/javascripts/hello.js
+$ sleep 3
 > scrapePlay
 -$ existsVersioned target/play-scrape/assets/javascripts/hello.js
+> existsVersioned target/play-scrape/assets/javascripts/hello-bak.js
 # reset
-$ copy-file public/javascripts/hello.js.bak public/javascripts/hello.js
-$ delete public/javascripts/hello.js.bak
+$ copy-file public/javascripts/hello-bak.js public/javascripts/hello.js
+$ delete public/javascripts/hello-bak.js


### PR DESCRIPTION
Most changes follow directly from upgrades. The following two changes were non-trivial:

* Use AWS `Builder` class to construct clients, consuming the new `scrapePublishRegion` key.
* Split out asset path determination from asset copying (refactor).

Additionally, sometime between play 2.6.2 and 2.6.12, play decided to change the key of `playAllAssets` from "/public" to "public/". This screwed up asset generation. This is mentioned in a comment [here](https://github.com/NetLogo/Play-Scraper/compare/wip-upgrade-sbt?expand=1#diff-b46f909e9080a880dc67a826106194c0R59).

Also, the version has been updated to 0.8.0, although I haven't published and don't plan to do so until the pull request is merged.